### PR TITLE
Fix bot polling call

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -1744,7 +1744,7 @@ async def main():
 
 
 
-    application.run_polling()
+    await application.run_polling()
 
 if __name__ == "__main__":
     import asyncio, logging


### PR DESCRIPTION
## Summary
- fix Telegram bot startup by awaiting `application.run_polling`

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6857c8c50e4c8321b1f6c21dceda8ae2