### PR TITLE
Implement team management features

### DIFF
--- a/battle.py
+++ b/battle.py
@@ -148,15 +148,15 @@ class BattleSession:
                     attacker_team1["injured"] = True
                     self.log.append(f"Травма: {attacker_team1['name']} покидает матч")
                 elif attacker_team1["strength"] < 25 and random.random() < 0.1 * penalty1:
-                    self.log.append(f"Удаление: {attacker_team1['name']} (team1)")
+                    self.log.append(f"Удаление: {attacker_team1['name']} ({self.name1})")
                 else:
                     if self._attempt_goal(attacker_team1, goalie_team2, attack_mod1, defense_mod2):
                         self.score["team1"] += 1
                         self.contribution[attacker_team1["name"]] += 1
-                        self.log.append(f"Гол: {attacker_team1['name']} (team1)")
+                        self.log.append(f"Гол: {attacker_team1['name']} ({self.name1})")
                     else:
                         self.contribution[goalie_team2["name"]] += 1
-                        self.log.append(f"Сейв: {goalie_team2['name']} (team2)")
+                        self.log.append(f"Сейв: {goalie_team2['name']} ({self.name2})")
                 # team2 attack
                 attacker_team2 = random.choice(self._attackers(self.team2))
                 goalie_team1 = self._goalie(self.team1)
@@ -164,15 +164,15 @@ class BattleSession:
                     attacker_team2["injured"] = True
                     self.log.append(f"Травма: {attacker_team2['name']} покидает матч")
                 elif attacker_team2["strength"] < 25 and random.random() < 0.1 * penalty2:
-                    self.log.append(f"Удаление: {attacker_team2['name']} (team2)")
+                    self.log.append(f"Удаление: {attacker_team2['name']} ({self.name2})")
                 else:
                     if self._attempt_goal(attacker_team2, goalie_team1, attack_mod2, defense_mod1):
                         self.score["team2"] += 1
                         self.contribution[attacker_team2["name"]] += 1
-                        self.log.append(f"Гол: {attacker_team2['name']} (team2)")
+                        self.log.append(f"Гол: {attacker_team2['name']} ({self.name2})")
                     else:
                         self.contribution[goalie_team1["name"]] += 1
-                        self.log.append(f"Сейв: {goalie_team1['name']} (team1)")
+                        self.log.append(f"Сейв: {goalie_team1['name']} ({self.name1})")
             self._apply_fatigue(self.team1)
             self._apply_fatigue(self.team2)
 

--- a/bot.py
+++ b/bot.py
@@ -1770,6 +1770,7 @@ def main():
     application.add_handler(CallbackQueryHandler(trade_page_callback, pattern="^trade_page_(prev|next)$"))
     application.add_handler(CommandHandler("editcard", editcard))
     application.add_handler(CallbackQueryHandler(editcard_callback, pattern="^(adminedit|admineditpage|admineditstat|admineditrarity|adminsetrarity)_?"))
+    application.add_handler(CommandHandler("myteam", handlers.show_my_team))
     application.add_handler(
         MessageHandler(filters.TEXT & (~filters.COMMAND), admin_text_handler),
         group=5,


### PR DESCRIPTION
## Summary
- add `show_my_team` handler to display team info with edit and rename options
- prevent `/team` command from starting if team already exists
- add rename step for team creation flow with length checks
- update battle logs to reference team names
- register new `/myteam` command before admin text handler

## Testing
- `python -m py_compile handlers.py battle.py bot.py db.py`

------
https://chatgpt.com/codex/tasks/task_e_6857fd3e0e248321854da952a735f94d