### PR TITLE
Implement leveling system with XP and unit tests

### DIFF
--- a/battle.py
+++ b/battle.py
@@ -115,6 +115,9 @@ class BattleSession:
             raise ValueError("Один или несколько игроков используются в обеих командах.")
         self._prepare_players(self.team1)
         self._prepare_players(self.team2)
+        self.avg_power1 = sum(p["strength"] for p in self.team1) / len(self.team1)
+        self.avg_power2 = sum(p["strength"] for p in self.team2) / len(self.team2)
+        self.str_gap = (self.avg_power2 - self.avg_power1) / max(self.avg_power1, 1)
 
     @staticmethod
     def _age(player: Dict) -> int:
@@ -156,6 +159,8 @@ class BattleSession:
         strength *= random.uniform(0.95, 1.05)  # form
         if country_count.get(player.get("country"), 0) >= 3:
             strength *= 1.05
+        lv_bonus = 1 + (player.get("owner_level", 1) // 5) * 0.02
+        strength *= lv_bonus
         return strength
 
     def _team_power(self, team: List[Dict], key: str) -> float:

--- a/helpers/leveling.py
+++ b/helpers/leveling.py
@@ -1,0 +1,27 @@
+BASE = 150
+
+def level_from_xp(xp: int) -> int:
+    """Параболическая кривая роста."""
+    return int((xp / BASE) ** 0.5) + 1
+
+def xp_to_next(xp: int) -> int:
+    lvl = level_from_xp(xp)
+    cap = BASE * (lvl ** 2)
+    return cap - xp
+
+def calc_battle_xp(result, *, is_pve: bool, streak: int, strength_gap: float) -> int:
+    win = result.get("winner") == "team1"
+    if is_pve:
+        base = 40 if win else 15
+    else:
+        base = 120 if win else 60
+    mod_strength = 1 + max(-0.5, min(strength_gap, 0.5))
+    mod_streak = 1 + min(max(streak - 1, 0), 5) * 0.1
+    anti_farm = 1.0
+    if is_pve and win:
+        if streak >= 10:
+            anti_farm = 0.0
+        elif streak >= 5:
+            anti_farm = 0.4
+    xp_gain = int(base * mod_strength * mod_streak * anti_farm)
+    return max(xp_gain, 0)

--- a/tests/test_leveling.py
+++ b/tests/test_leveling.py
@@ -1,0 +1,52 @@
+import types
+import os, sys
+import pytest
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from helpers import leveling
+
+
+def test_level_curve():
+    assert leveling.level_from_xp(0) == 1
+    assert leveling.level_from_xp(2400) == 5
+    assert leveling.level_from_xp(13500) == 10
+
+
+def test_pvp_more_than_pve():
+    res = {"winner": "team1", "str_gap": 0}
+    pvp = leveling.calc_battle_xp(res, is_pve=False, streak=1, strength_gap=0)
+    pve = leveling.calc_battle_xp(res, is_pve=True, streak=1, strength_gap=0)
+    assert pvp > pve
+
+
+def test_antifarm_zero_after_11():
+    res = {"winner": "team1", "str_gap": 0}
+    xp = leveling.calc_battle_xp(res, is_pve=True, streak=11, strength_gap=0)
+    assert xp == 0
+
+
+def test_level_up_triggers_reward(monkeypatch):
+    called = {}
+
+    async def fake_reward(uid, lvl, ctx):
+        called['lvl'] = lvl
+
+    try:
+        import handlers
+    except ModuleNotFoundError:
+        pytest.skip("telegram not available")
+    monkeypatch.setattr(handlers, 'grant_level_reward', fake_reward)
+    user_id = 1
+    ctx = types.SimpleNamespace(bot=types.SimpleNamespace(send_message=lambda *a, **kw: None))
+    res = {"winner": "team1", "str_gap": 0}
+    # ensure db has user
+    import db
+    conn = db.get_db()
+    c = conn.cursor()
+    c.execute("INSERT OR REPLACE INTO users (id, username) VALUES (?, ?)", (user_id, 'test'))
+    conn.commit()
+    conn.close()
+    # force level up
+    db.update_xp(user_id, 150*10, 10, 0)
+    import asyncio
+    asyncio.run(handlers.apply_xp(user_id, res, True, ctx))
+    assert called.get('lvl') is not None


### PR DESCRIPTION
## Summary
- add XP and level columns to DB setup
- implement leveling helpers and XP calculation
- apply XP gain after battles and update win streaks
- modify ranking and profile commands to show level
- add `/xp` and `/topxp` commands
- unit tests for leveling logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858420cdb3083218fdda3f702f6514c