### PR TITLE
Fix battle session duplicates

### DIFF
--- a/battle.py
+++ b/battle.py
@@ -109,10 +109,6 @@ class BattleSession:
         self.log: List[str] = []
         self.score = {"team1": 0, "team2": 0}
         self.contribution = defaultdict(int)
-        ids1 = {p["id"] for p in self.team1}
-        ids2 = {p["id"] for p in self.team2}
-        if ids1 & ids2:
-            raise ValueError("Один или несколько игроков используются в обеих командах.")
         self._prepare_players(self.team1)
         self._prepare_players(self.team2)
         self.avg_power1 = sum(p["strength"] for p in self.team1) / len(self.team1)

--- a/tests/test_battle.py
+++ b/tests/test_battle.py
@@ -1,0 +1,23 @@
+import os, sys
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from battle import BattleSession
+
+def make_player(id=1):
+    return {
+        'id': id,
+        'name': f'P{id}',
+        'pos': 'F',
+        'points': 50,
+        'country': 'CA',
+        'born': '1990',
+        'weight': '90',
+        'rarity': 'common',
+        'owner_level': 1,
+    }
+
+def test_same_player_ids_across_teams_ok():
+    team1 = [make_player(1), make_player(2)]
+    team2 = [make_player(1), make_player(3)]
+    session = BattleSession(team1, team2)
+    res = session.simulate()
+    assert 'winner' in res


### PR DESCRIPTION
## Summary
- allow duplicate player ids across teams
- add regression test to ensure battle simulation works with shared ids

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68584fec5dfc8321ac3bc568fcec5d6a