### PR TITLE
Fix total card count display

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -1520,7 +1520,6 @@ async def send_collection_page(
         lines.append("")
 
     total_cards = sum(r[3] for r in card_info)
-    unique_total = len(card_info)
     total_pages = (len(card_info) + CARDS_PER_PAGE - 1) // CARDS_PER_PAGE
 
     nav = []
@@ -1547,7 +1546,7 @@ async def send_collection_page(
 
     text = (
         f"{title} (стр. {page+1} из {total_pages}):\n\n" + "\n".join(lines).rstrip()
-        + f"\n\nВсего у тебя: {total_cards} карточек (уникальных: {unique_total})"
+        + f"\n\n📦 Всего: {total_cards} карт"
     )
 
     if edit_message and message_id:


### PR DESCRIPTION
## Summary
- always show overall card copies in collection page
- drop mention of unique cards in card count

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859d540bf448321b3ac368416aa211f