### PR TITLE
Implement central admin permissions

### DIFF
--- a/helpers/permissions.py
+++ b/helpers/permissions.py
@@ -1,0 +1,21 @@
+ADMINS = [445479731, 6463889816]  # указать реальные ID
+
+
+def is_admin(user_id: int) -> bool:
+    return user_id in ADMINS
+
+from functools import wraps
+from telegram import Update
+from telegram.ext import ContextTypes
+
+
+def admin_only(func):
+    @wraps(func)
+    async def wrapper(update: Update, context: ContextTypes.DEFAULT_TYPE, *args, **kwargs):
+        user = update.effective_user
+        if not is_admin(user.id):
+            await update.message.reply_text("⛔️ Команда доступна только администраторам.")
+            return
+        return await func(update, context, *args, **kwargs)
+
+    return wrapper


### PR DESCRIPTION
## Summary
- centralize admin checks in `helpers/permissions.py`
- import and use the new permissions helpers in `bot.py`
- decorate admin commands with `@admin_only`
- remove duplicated admin ID checks

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ae38126c883219542b379bf19d853