### PR TITLE
Migrate bot to PostgreSQL and webhook

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -1,7 +1,6 @@
 import os
 import time
 import random
-import sqlite3
 import re
 import asyncio
 import logging
@@ -48,7 +47,7 @@ from telegram import (
 from collections import Counter
 from functools import wraps
 import handlers
-import db
+import db_pg as db
 from helpers.leveling import xp_to_next
 from helpers import shorten_number, format_ranking_row, format_my_rank
 from helpers.permissions import ADMINS, is_admin, admin_only
@@ -259,8 +258,7 @@ TRADE_NHL_PHRASES = [
 ]
 
 def get_db():
-    conn = sqlite3.connect(os.path.join(os.path.dirname(__file__), 'botdb.sqlite'))
-    return conn
+    return db.get_db()
 
 def setup_db():
     conn = get_db()
@@ -268,36 +266,36 @@ def setup_db():
     c.execute('CREATE TABLE IF NOT EXISTS users (id INTEGER PRIMARY KEY, username TEXT, last_card_time INTEGER)')
     try:
         c.execute("ALTER TABLE users ADD COLUMN last_week_score INTEGER DEFAULT 0")
-    except sqlite3.OperationalError:
+    except Exception:
         pass
     try:
         c.execute("ALTER TABLE users ADD COLUMN referrals_count INTEGER DEFAULT 0")
-    except sqlite3.OperationalError:
+    except Exception:
         pass
     try:
         c.execute("ALTER TABLE users ADD COLUMN invited_by INTEGER DEFAULT NULL")
-    except sqlite3.OperationalError:
+    except Exception:
         pass
     try:
         c.execute("ALTER TABLE users ADD COLUMN xp INTEGER DEFAULT 0")
-    except sqlite3.OperationalError:
+    except Exception:
         pass
     try:
         c.execute("ALTER TABLE users ADD COLUMN level INTEGER DEFAULT 1")
-    except sqlite3.OperationalError:
+    except Exception:
         pass
     try:
         c.execute("ALTER TABLE users ADD COLUMN xp_daily INTEGER DEFAULT 0")
-    except sqlite3.OperationalError:
+    except Exception:
         pass
     try:
         c.execute("ALTER TABLE users ADD COLUMN last_xp_reset DATE")
         c.execute("UPDATE users SET last_xp_reset = DATE('now') WHERE last_xp_reset IS NULL")
-    except sqlite3.OperationalError:
+    except Exception:
         pass
     try:
         c.execute("ALTER TABLE users ADD COLUMN win_streak INTEGER DEFAULT 0")
-    except sqlite3.OperationalError:
+    except Exception:
         pass
     # ... остальной код создания таблиц ...
     conn.commit()

--- a/db_pg.py
+++ b/db_pg.py
@@ -1,0 +1,204 @@
+import os
+import json
+import psycopg2
+from dotenv import load_dotenv
+
+load_dotenv()
+
+class PGCursor:
+    def __init__(self, cur):
+        self._cur = cur
+    def execute(self, query, params=None):
+        if params is None:
+            params = ()
+        self._cur.execute(query.replace('?', '%s'), params)
+    def executemany(self, query, seq):
+        self._cur.executemany(query.replace('?', '%s'), seq)
+    def fetchone(self):
+        return self._cur.fetchone()
+    def fetchall(self):
+        return self._cur.fetchall()
+    def __iter__(self):
+        return iter(self._cur)
+    def close(self):
+        self._cur.close()
+
+class PGConnection:
+    def __init__(self, conn):
+        self._conn = conn
+    def cursor(self):
+        return PGCursor(self._conn.cursor())
+    def execute(self, query, params=None):
+        cur = self.cursor()
+        cur.execute(query, params)
+        return cur
+    def commit(self):
+        self._conn.commit()
+    def close(self):
+        self._conn.close()
+
+
+def get_db():
+    conn = psycopg2.connect(
+        host=os.getenv('PG_HOST'),
+        port=os.getenv('PG_PORT'),
+        dbname=os.getenv('PG_DB'),
+        user=os.getenv('PG_USER'),
+        password=os.getenv('PG_PASSWORD'),
+    )
+    return PGConnection(conn)
+
+
+def setup_battle_db():
+    conn = get_db()
+    conn.execute(
+        '''
+        CREATE TABLE IF NOT EXISTS battles (
+            id SERIAL PRIMARY KEY,
+            user_id INTEGER,
+            opponent TEXT,
+            result TEXT,
+            score_team1 INTEGER,
+            score_team2 INTEGER,
+            mvp TEXT,
+            log TEXT,
+            timestamp TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        )
+        '''
+    )
+    conn.commit()
+    conn.close()
+
+
+def save_battle_result(user_id, opponent_name, result):
+    conn = get_db()
+    conn.execute(
+        '''
+        INSERT INTO battles (user_id, opponent, result, score_team1, score_team2, mvp, log)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+        ''',
+        (
+            user_id,
+            opponent_name,
+            result["winner"],
+            result["score"]["team1"],
+            result["score"]["team2"],
+            result["mvp"],
+            json.dumps(result["log"]),
+        ),
+    )
+    conn.commit()
+    conn.close()
+
+
+def get_battle_history(user_id, limit=5):
+    conn = get_db()
+    cur = conn.execute(
+        '''SELECT timestamp, opponent, result, score_team1, score_team2, mvp
+           FROM battles WHERE user_id=? ORDER BY id DESC LIMIT ?''',
+        (user_id, limit),
+    )
+    rows = cur.fetchall()
+    conn.close()
+    return rows
+
+
+def setup_team_db():
+    conn = get_db()
+    conn.execute(
+        '''
+        CREATE TABLE IF NOT EXISTS teams (
+            user_id INTEGER PRIMARY KEY,
+            name TEXT,
+            lineup TEXT,
+            bench TEXT
+        )
+        '''
+    )
+    conn.commit()
+    conn.close()
+
+
+def save_team(user_id, name, lineup, bench):
+    conn = get_db()
+    conn.execute(
+        '''REPLACE INTO teams (user_id, name, lineup, bench) VALUES (?, ?, ?, ?)''',
+        (user_id, name, json.dumps(lineup), json.dumps(bench)),
+    )
+    conn.commit()
+    conn.close()
+
+
+def get_team(user_id):
+    conn = get_db()
+    cur = conn.execute(
+        'SELECT name, lineup, bench FROM teams WHERE user_id=?',
+        (user_id,),
+    )
+    row = cur.fetchone()
+    conn.close()
+    if row:
+        return {
+            'name': row[0],
+            'lineup': json.loads(row[1] or '[]'),
+            'bench': json.loads(row[2] or '[]'),
+        }
+    return None
+
+
+def team_name_taken(name: str, exclude_user_id: int) -> bool:
+    conn = get_db()
+    cur = conn.execute(
+        'SELECT user_id FROM teams WHERE name=? AND user_id != ?',
+        (name, exclude_user_id),
+    )
+    row = cur.fetchone()
+    conn.close()
+    return row is not None
+
+
+def get_xp_level(uid: int):
+    conn = get_db()
+    cur = conn.execute('SELECT xp, level FROM users WHERE id=?', (uid,))
+    row = cur.fetchone()
+    conn.close()
+    if row:
+        return row[0], row[1]
+    return 0, 1
+
+
+def update_xp(uid: int, xp: int, level: int, delta: int):
+    conn = get_db()
+    conn.execute(
+        'UPDATE users SET xp=?, level=?, xp_daily = xp_daily + ?, last_xp_reset=last_xp_reset WHERE id=?',
+        (xp, level, delta, uid),
+    )
+    conn.commit()
+    conn.close()
+
+
+def reset_daily_xp():
+    conn = get_db()
+    conn.execute(
+        "UPDATE users SET xp_daily=0, last_xp_reset=CURRENT_DATE WHERE last_xp_reset < CURRENT_DATE"
+    )
+    conn.commit()
+    conn.close()
+
+
+def get_win_streak(uid: int) -> int:
+    conn = get_db()
+    cur = conn.execute('SELECT win_streak FROM users WHERE id=?', (uid,))
+    row = cur.fetchone()
+    conn.close()
+    return row[0] if row else 0
+
+
+def update_win_streak(uid: int, won: bool):
+    streak = get_win_streak(uid)
+    streak = streak + 1 if won else 0
+    conn = get_db()
+    conn.execute('UPDATE users SET win_streak=? WHERE id=?', (streak, uid))
+    conn.commit()
+    conn.close()
+    return streak

--- a/handlers.py
+++ b/handlers.py
@@ -6,7 +6,7 @@ from telegram import InlineKeyboardButton, InlineKeyboardMarkup, Update
 from telegram.ext import ContextTypes
 from telegram.error import BadRequest
 from battle import BattleSession
-import db
+import db_pg as db
 from helpers.leveling import level_from_xp, xp_to_next, calc_battle_xp
 
 level_up_msg = "🆙 *Новый уровень!*  Ты достиг Lv {lvl}.\n🎁 Твой приз: {reward}"

--- a/migrate_to_postgres.py
+++ b/migrate_to_postgres.py
@@ -1,0 +1,37 @@
+import os
+import sqlite3
+import psycopg2
+from dotenv import load_dotenv
+
+load_dotenv()
+
+SQLITE_DB = os.path.join(os.path.dirname(__file__), 'botdb.sqlite')
+
+pg_conn = psycopg2.connect(
+    host=os.getenv('PG_HOST'),
+    port=os.getenv('PG_PORT'),
+    dbname=os.getenv('PG_DB'),
+    user=os.getenv('PG_USER'),
+    password=os.getenv('PG_PASSWORD'),
+)
+pg_cur = pg_conn.cursor()
+
+sqlite_conn = sqlite3.connect(SQLITE_DB)
+sqlite_cur = sqlite_conn.cursor()
+
+TABLES = ['users', 'cards', 'inventory', 'teams', 'battles']
+for table in TABLES:
+    sqlite_cur.execute(f'SELECT * FROM {table}')
+    rows = sqlite_cur.fetchall()
+    if not rows:
+        continue
+    cols = [desc[0] for desc in sqlite_cur.description]
+    placeholders = ','.join(['%s'] * len(cols))
+    col_list = ', '.join(cols)
+    insert_q = f'INSERT INTO {table} ({col_list}) VALUES ({placeholders})'
+    for row in rows:
+        pg_cur.execute(insert_q, row)
+
+pg_conn.commit()
+pg_conn.close()
+sqlite_conn.close()

--- a/set_webhook.py
+++ b/set_webhook.py
@@ -1,6 +1,10 @@
+import os
 import requests
+from dotenv import load_dotenv
 
-TOKEN = "7649956181:AAErINkWzZJ7BofoorAHxc2fLXMPoaCjkQM"
+load_dotenv()
+
+TOKEN = os.getenv("BOT_TOKEN")
 URL = f"https://Vitaly24.pythonanywhere.com/webhook/{TOKEN}"
 
 res = requests.get(f"https://api.telegram.org/bot{TOKEN}/setWebhook?url={URL}")

--- a/webhook.py
+++ b/webhook.py
@@ -7,7 +7,7 @@ from dotenv import load_dotenv
 # Загрузка переменных
 load_dotenv()
 
-TOKEN = "7649956181:AAErINkWzZJ7BofoorAHxc2fLXMPoaCjkQM"
+TOKEN = os.getenv("BOT_TOKEN")
 bot = Bot(TOKEN)
 application = Application.builder().token(TOKEN).build()
 


### PR DESCRIPTION
## Summary
- add PostgreSQL database backend `db_pg.py`
- refactor bot and handlers to use new backend
- load bot token from environment in webhook server and `set_webhook.py`
- add migration helper `migrate_to_postgres.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c3769f42c83218b2d609eebd48629