### PR TITLE
Fix Postgres query quoting

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -337,7 +337,7 @@ def _get_random_card_sync():
         'SELECT * FROM cards WHERE rarity=? '
         'AND img NOT LIKE "%default-skater.png%" '
         'AND img NOT LIKE "%default-goalie.png%" '
-        'AND img != "" AND img IS NOT NULL '
+        'AND img != \'\' AND img IS NOT NULL '
         'ORDER BY RANDOM() LIMIT 1',
         (rarity,)
     )


### PR DESCRIPTION
## Summary
- fix quoting for empty string in `_get_random_card_sync`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c47bd57ec8321b055dae3328c5dd2