### PR TITLE
Fix weekly progress calculation when last_week_score is NULL

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -572,7 +572,7 @@ def get_weekly_progress(user_id):
     row = c.fetchone()
     conn.close()
     current = get_user_score_cached_sync(user_id)
-    last = row[0] if row else 0
+    last = row[0] if row and row[0] is not None else 0
     return current - last
 
 def _get_top_users_sync(limit=10):


### PR DESCRIPTION
## Summary
- handle NULL `last_week_score` in weekly progress calculation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d9dc1405c8321aeff50f5ab1f76af