### PR TITLE
Fix XP level retrieval when db fields are NULL

### DIFF
--- a/db.py
+++ b/db.py
@@ -193,7 +193,9 @@ def get_xp_level(uid: int):
     row = cur.fetchone()
     conn.close()
     if row:
-        return row[0], row[1]
+        xp = row[0] if row[0] is not None else 0
+        lvl = row[1] if row[1] is not None else 1
+        return xp, lvl
     return 0, 1
 
 

--- a/db_pg.py
+++ b/db_pg.py
@@ -185,7 +185,9 @@ def get_xp_level(uid: int):
     row = cur.fetchone()
     conn.close()
     if row:
-        return row[0], row[1]
+        xp = row[0] if row[0] is not None else 0
+        level = row[1] if row[1] is not None else 1
+        return xp, level
     return 0, 1
 
 

--- a/tests/test_leveling.py
+++ b/tests/test_leveling.py
@@ -81,3 +81,31 @@ def test_grant_level_reward_adds_cards(monkeypatch):
     count = c.fetchone()[0]
     conn.close()
     assert count == 2
+
+
+def test_get_xp_level_defaults_when_null():
+    import db, sqlite3
+
+    uid = 99
+    conn = db.get_db()
+    cur = conn.cursor()
+    # ensure columns exist
+    try:
+        cur.execute("ALTER TABLE users ADD COLUMN xp INTEGER")
+    except sqlite3.OperationalError:
+        pass
+    try:
+        cur.execute("ALTER TABLE users ADD COLUMN level INTEGER")
+    except sqlite3.OperationalError:
+        pass
+    cur.execute("DELETE FROM users WHERE id=?", (uid,))
+    cur.execute(
+        "INSERT INTO users (id, username, xp, level) VALUES (?, ?, NULL, NULL)",
+        (uid, 'n'),
+    )
+    conn.commit()
+    conn.close()
+
+    xp, lvl = db.get_xp_level(uid)
+    assert xp == 0
+    assert lvl == 1


### PR DESCRIPTION
## Summary
- avoid `None` values in `get_xp_level`
- test default XP/level handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d9ea617588321b13c2351071c0df7