### PR TITLE
Fix inventory timestamp for PostgreSQL

### DIFF
--- a/handlers.py
+++ b/handlers.py
@@ -22,7 +22,7 @@ async def grant_level_reward(uid: int, lvl: int, context: ContextTypes.DEFAULT_T
         if not card:
             continue
         cur.execute(
-            "INSERT INTO inventory (user_id, card_id, time_got) VALUES (?, ?, strftime('%s','now'))",
+            "INSERT INTO inventory (user_id, card_id, time_got) VALUES (?, ?, EXTRACT(EPOCH FROM NOW())::bigint)",
             (uid, card["id"]),
         )
         cards.append(card)


### PR DESCRIPTION
## Summary
- fix timestamp insertion in `handlers.py` for PostgreSQL

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685da201933883218c98987a2c2f6210