### PR TITLE
Integrate match flow into battles

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -2470,12 +2470,11 @@ def main():
     application.add_handler(CallbackQueryHandler(handlers.team_callback, pattern="^team_"))
     application.add_handler(MessageHandler(filters.TEXT & (~filters.COMMAND), handlers.team_text_handler))
     application.add_handler(CommandHandler("fight", handlers.start_fight))
-    application.add_handler(CommandHandler("match", handlers.start_match))
     application.add_handler(CommandHandler("duel", handlers.start_duel))
     application.add_handler(CommandHandler("duel_list", handlers.duel_list))
     application.add_handler(CommandHandler("history", handlers.show_battle_history))
     application.add_handler(CallbackQueryHandler(handlers.tactic_callback, pattern="^tactic_"))
-    application.add_handler(CallbackQueryHandler(handlers.match_callback, pattern="^match_"))
+    application.add_handler(CallbackQueryHandler(handlers.battle_callback, pattern="^battle_"))
     application.add_handler(CallbackQueryHandler(handlers.duel_callback, pattern="^(challenge_\\d+|duel_cancel)$"))
     application.add_handler(CallbackQueryHandler(handlers.log_callback, pattern="^log_(prev|next|close)$"))
 


### PR DESCRIPTION
## Summary
- embed the match flow into standard `/fight` command
- add a `BattleController` to handle step-by-step play
- provide `battle_callback` for interactive periods
- drop `/match` command and its handlers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685eb441f07c8321bdcabe2499846797