### PR TITLE
Revamp final match summary

### DIFF
--- a/battle.py
+++ b/battle.py
@@ -353,13 +353,6 @@ class BattleSession:
             winner = "draw"
 
         mvp = max(self.contribution.items(), key=lambda x: x[1])[0] if self.contribution else ""
-        self.log.append(f"Финальный счёт: {self.score['team1']} - {self.score['team2']}")
-        if winner == "team1":
-            self.log.append(f"<b>Победа {self.name1}</b>")
-        elif winner == "team2":
-            self.log.append(f"<b>Победа {self.name2}</b>")
-        else:
-            self.log.append("<b>Ничья</b>")
         return {
             "winner": winner,
             "score": self.score,


### PR DESCRIPTION
## Summary
- trim final logs from BattleSession
- add dynamic final summary commentary
- return XP gain from `apply_xp`
- show elite summary after battles with XP info

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f1d956e8c8321a768eec52509161f