### PR TITLE
Improve battle log UX

### DIFF
--- a/battle.py
+++ b/battle.py
@@ -380,10 +380,12 @@ class BattleSession:
             "str_gap": self.str_gap,
         }
 
-    def simulate(self) -> Dict:
-        """Run a full match using :class:`BattleController`."""
-        controller = BattleController(self)
-        return controller.auto_play()
+
+    # Deprecated old simulation helper that returned verbose logs
+    # def simulate(self) -> Dict:
+    #     """Run a full match using :class:`BattleController`."""
+    #     controller = BattleController(self)
+    #     return controller.auto_play()
 
 
 class BattleController:

--- a/helpers/commentary.py
+++ b/helpers/commentary.py
@@ -100,51 +100,22 @@ def format_period_summary(session: BattleSession) -> str:
 
 
 def format_final_summary(session: BattleSession, result: dict, xp_gain: int, level: int, leveled_up: bool = False) -> str:
-    """Generate short final match summary."""
+    """Generate concise final match summary."""
     s1 = result.get("score", {}).get("team1", 0)
     s2 = result.get("score", {}).get("team2", 0)
-    if result.get("winner") == "team1":
-        header = f"🏆 Матч завершён! Победа {session.name1} со счётом {s1} — {s2}"
-    elif result.get("winner") == "team2":
-        header = f"🏆 Матч завершён! Победа {session.name2} со счётом {s1} — {s2}"
-    else:
-        header = f"🏁 Матч завершён! Ничья {s1} — {s2}"
+    header = f"🏆 Матч окончен: <i>{session.name1}</i> {s1} — {s2} <i>{session.name2}</i>"
 
     parts: List[str] = [header]
 
     mvp = result.get("mvp")
     if mvp:
-        player = next((p for p in session.team1 + session.team2 if p["name"] == mvp), {})
-        contrib = session.contribution.get(mvp, 0)
-        if (player.get("pos") or "").startswith("G"):
-            parts.append(f"🎯 Звезда матча: {mvp} — {contrib} сейвов")
-        else:
-            parts.append(f"🎯 Звезда матча: {mvp} — {contrib} очка")
-
-    goalies = [p for p in session.team1 + session.team2 if (p.get("pos") or "").startswith("G")]
-    if goalies:
-        best = max(goalies, key=lambda g: session.contribution.get(g["name"], 0))
-        saves = session.contribution.get(best["name"], 0)
-        team = session.name1 if best in session.team1 else session.name2
-        parts.append(f"🛡 {best['name']} ({team}) сделал {saves} сейвов — потрясающе!")
-
-    if random.random() < 0.15:
-        template = random.choice(MEME_CLIPS)
-    else:
-        template = random.choice(FAN_CLIPS + EXPERT_CLIPS)
-
-    if "{player}" in template:
-        name, team = _random_player(session)
-        parts.append(template.format(player=name, team=team, team1=session.name1, team2=session.name2))
-    elif "{goalie}" in template:
-        name, team = _random_goalie(session)
-        parts.append(template.format(goalie=name, team=team, team1=session.name1, team2=session.name2))
-    else:
-        parts.append(template.format(team=session.name1, team1=session.name1, team2=session.name2))
+        goals = sum(1 for g in session.goals if g["player"] == mvp)
+        goal_word = "гол" if goals == 1 else "гола"
+        parts.append(f"🎯 Звезда матча: <b>{mvp}</b> — {goals} {goal_word}")
 
     if leveled_up:
-        parts.append(f"🎖 Ты получаешь +{xp_gain} XP и переходишь на уровень {level}!")
+        parts.append(f"🎖 +{xp_gain} XP, рейтинг +1")
     else:
-        parts.append(f"🎖 +{xp_gain} XP")
+        parts.append(f"🎖 +{xp_gain} XP, рейтинг +1")
 
-    return "\n\n".join(parts)
+    return "\n".join(parts)

--- a/helpers/premium.py
+++ b/helpers/premium.py
@@ -8,6 +8,20 @@ def generate_premium_log(session: BattleSession, result: dict, xp_gain: int = 85
     """Generate telecast-style premium log for the match."""
     lines: List[str] = []
 
+    # XP reward block
+    mvp = result.get("mvp")
+    goals_by_player = defaultdict(int)
+    for g in session.goals:
+        goals_by_player[g["player"]] += 1
+    reason = "за отличную игру!"
+    if result.get("winner") in ("team1", "team2"):
+        top_goals = goals_by_player.get(mvp, 0)
+        if mvp and top_goals >= 2:
+            reason = f"за дубль {mvp} и уверенную победу!"
+        else:
+            reason = "за уверенную победу!"
+    lines.append(f"💎 <b>+{xp_gain} XP {reason}</b>")
+
     # group goals by period to match scoreboard
     goals_by_period: DefaultDict[int, List[Dict]] = defaultdict(list)
     for g in session.goals:
@@ -54,7 +68,9 @@ def generate_premium_log(session: BattleSession, result: dict, xp_gain: int = 85
     # Final summary block
     s1 = result.get("score", {}).get("team1", 0)
     s2 = result.get("score", {}).get("team2", 0)
-    lines.append(f"🏆 Матч окончен: {session.name1} {s1} — {s2} {session.name2}")
+    lines.append(
+        f"🏆 Матч окончен: <i>{session.name1}</i> {s1} — {s2} <i>{session.name2}</i>"
+    )
     mvp = result.get("mvp")
     if mvp:
         goals = sum(1 for g in session.goals if g["player"] == mvp)

--- a/tests/test_battle.py
+++ b/tests/test_battle.py
@@ -1,6 +1,6 @@
 import os, sys
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
-from battle import BattleSession
+from battle import BattleSession, BattleController
 import random
 
 def make_player(id=1):
@@ -21,7 +21,8 @@ def test_same_player_ids_across_teams_ok():
     team1 = [make_player(1), make_player(2)]
     team2 = [make_player(1), make_player(3)]
     session = BattleSession(team1, team2)
-    res = session.simulate()
+    controller = BattleController(session)
+    res = controller.auto_play()
     assert 'winner' in res
 
 
@@ -30,5 +31,6 @@ def test_battle_returns_strength_gap():
     team1 = [make_player(1), make_player(2)]
     team2 = [make_player(3), make_player(4)]
     session = BattleSession(team1, team2)
-    res = session.simulate()
+    controller = BattleController(session)
+    res = controller.auto_play()
     assert 'str_gap' in res


### PR DESCRIPTION
## Summary
- redesign battle logs with premium style
- increase log page size
- drop outdated simulation helpers
- simplify final summary
- adjust tests to use controller

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685fb407ea24832190c1a5d7ad293a75