### PR TITLE
Simplify battle log output

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -2476,7 +2476,6 @@ def main():
     application.add_handler(CallbackQueryHandler(handlers.tactic_callback, pattern="^tactic_"))
     application.add_handler(CallbackQueryHandler(handlers.battle_callback, pattern="^battle_"))
     application.add_handler(CallbackQueryHandler(handlers.duel_callback, pattern="^(challenge_\\d+|duel_cancel)$"))
-    application.add_handler(CallbackQueryHandler(handlers.log_callback, pattern="^log_(prev|next|close)$"))
 
 
 

--- a/helpers/premium.py
+++ b/helpers/premium.py
@@ -4,7 +4,7 @@ from collections import defaultdict
 from battle import BattleSession
 
 
-def generate_premium_log(session: BattleSession, result: dict, xp_gain: int = 85, rating_delta: int = 1) -> List[str]:
+def generate_premium_log(session: BattleSession, result: dict, xp_gain: int = 85, rating_delta: int = 1) -> str:
     """Generate telecast-style premium log for the match."""
     lines: List[str] = []
 
@@ -78,4 +78,4 @@ def generate_premium_log(session: BattleSession, result: dict, xp_gain: int = 85
         lines.append(f"🎯 Звезда матча: <b>{mvp}</b> — {goals} {goal_word}")
     lines.append(f"🎖 +{xp_gain} XP, рейтинг +{rating_delta}")
 
-    return lines
+    return "\n".join(lines)


### PR DESCRIPTION
## Summary
- remove pagination logic from handlers and bot
- generate entire rich log as one string

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685fb92e5d1083218ca37d5d76b44a66