### PR TITLE
Improve MVP summary

### DIFF
--- a/helpers/commentary.py
+++ b/helpers/commentary.py
@@ -123,10 +123,24 @@ def format_final_summary(session: BattleSession, result: dict, xp_gain: int, lev
     goals_by_player = defaultdict(int)
     for g in session.goals:
         goals_by_player[g["player"]] += 1
+
+    players = {p["name"]: p for p in session.team1 + session.team2}
+    saves_by_player = defaultdict(int)
+    for e in session.events:
+        if (
+            e.get("type") == "save"
+            and players.get(e.get("player"), {}).get("pos") == "G"
+        ):
+            saves_by_player[e["player"]] += 1
+
     if mvp:
-        goals = goals_by_player.get(mvp, 0)
-        goal_word = "гол" if goals == 1 else "гола"
-        parts.append(f"🎯 Звезда матча: <b>{mvp}</b> — {goals} {goal_word}")
+        if players.get(mvp, {}).get("pos") == "G":
+            saves = saves_by_player.get(mvp, 0)
+            parts.append(f"🎯 Звезда матча: <b>{mvp}</b> — {saves} сейвов")
+        else:
+            goals = goals_by_player.get(mvp, 0)
+            goal_word = "гол" if goals == 1 else "гола"
+            parts.append(f"🎯 Звезда матча: <b>{mvp}</b> — {goals} {goal_word}")
 
 
     # XP reward is sent separately, so do not include it in the summary

--- a/helpers/premium.py
+++ b/helpers/premium.py
@@ -73,9 +73,18 @@ def generate_premium_log(session: BattleSession, result: dict, xp_gain: int = 85
     )
     mvp = result.get("mvp")
     if mvp:
-        goals = sum(1 for g in session.goals if g["player"] == mvp)
-        goal_word = "гол" if goals == 1 else "гола"
-        lines.append(f"🎯 Звезда матча: <b>{mvp}</b> — {goals} {goal_word}")
+        players = {p["name"]: p for p in session.team1 + session.team2}
+        if players.get(mvp, {}).get("pos") == "G":
+            saves = sum(
+                1
+                for e in session.events
+                if e.get("type") == "save" and e.get("player") == mvp
+            )
+            lines.append(f"🎯 Звезда матча: <b>{mvp}</b> — {saves} сейвов")
+        else:
+            goals = sum(1 for g in session.goals if g["player"] == mvp)
+            goal_word = "гол" if goals == 1 else "гола"
+            lines.append(f"🎯 Звезда матча: <b>{mvp}</b> — {goals} {goal_word}")
 
     # XP and rating changes are delivered separately
 

--- a/tests/test_battle.py
+++ b/tests/test_battle.py
@@ -86,3 +86,40 @@ def test_mvp_based_on_stats():
     max_saves = max(saves.values(), default=0)
     top_goalies = {n for n, s in saves.items() if s == max_saves and s > 0}
     assert res['mvp'] in top_scorers.union(top_goalies)
+
+
+def test_summary_shows_goals_for_field_player():
+    from helpers.commentary import format_final_summary
+
+    # create session with one scorer field player
+    team1 = [make_player(1)]
+    team2 = [make_player(2)]
+    session = BattleSession(team1, team2)
+    session.goals = [{"player": "P1", "team": "A", "period": 1}]
+    session.events = []
+    result = {"score": {"team1": 1, "team2": 0}, "mvp": "P1"}
+
+    summary = format_final_summary(session, result, 0, 1)
+    assert "P1" in summary
+    assert "1 гол" in summary
+
+
+def test_summary_shows_saves_for_goalie():
+    from helpers.commentary import format_final_summary
+
+    # goalie MVP with saves
+    gk = make_player(3)
+    gk['pos'] = 'G'
+    team1 = [gk]
+    team2 = [make_player(4)]
+    session = BattleSession(team1, team2)
+    session.goals = []
+    session.events = [
+        {"player": "P3", "type": "save"},
+        {"player": "P3", "type": "save"},
+    ]
+    result = {"score": {"team1": 0, "team2": 0}, "mvp": "P3"}
+
+    summary = format_final_summary(session, result, 0, 1)
+    assert "P3" in summary
+    assert "2 сейвов" in summary


### PR DESCRIPTION
## Summary
- show saves if goalie earns MVP
- unit tests for goal/saves summary logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860414209908321b2a1c581efe1072e