### PR TITLE
Improve team listing format

### DIFF
--- a/handlers.py
+++ b/handlers.py
@@ -206,7 +206,9 @@ async def show_my_team(update: Update, context: ContextTypes.DEFAULT_TYPE):
             rarity_emoji = RARITY_EMOJI.get(rarity, "")
             rarity_ru = RARITY_RU_SHORT.get(rarity, rarity)
             points = int(card.get("points", 0))
-            lines.append(f"{pos_icon} <b>{card['name']}</b> — Очки: {points}, {rarity_emoji} {rarity_ru}, {pos}")
+            lines.append(f"{pos_icon} <b>{card['name']}</b>")
+            lines.append(f"Очки: {points}, {rarity_emoji} {rarity_ru}, {pos}")
+            lines.append("")
     else:
         lines.append("—")
 
@@ -219,7 +221,9 @@ async def show_my_team(update: Update, context: ContextTypes.DEFAULT_TYPE):
             rarity_emoji = RARITY_EMOJI.get(rarity, "")
             rarity_ru = RARITY_RU_SHORT.get(rarity, rarity)
             points = int(card.get("points", 0))
-            lines.append(f"{pos_icon} <b>{card['name']}</b> — Очки: {points}, {rarity_emoji} {rarity_ru}, {pos}")
+            lines.append(f"{pos_icon} <b>{card['name']}</b>")
+            lines.append(f"Очки: {points}, {rarity_emoji} {rarity_ru}, {pos}")
+            lines.append("")
     else:
         lines.append("—")
 


### PR DESCRIPTION
## Summary
- display each player's name on its own line in `/team`
- add a blank line after every player for readability

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68604a615dcc8321b0d7ee3d7d86b06f