### PR TITLE
Add admin command suite with usage tracking

### DIFF
--- a/handlers.py
+++ b/handlers.py
@@ -533,6 +533,10 @@ async def team_callback(update: Update, context: ContextTypes.DEFAULT_TYPE):
 
 async def start_fight(update: Update, context: ContextTypes.DEFAULT_TYPE):
     """Начать интерактивный бой против бота."""
+    from helpers.admin_utils import banned_users
+    if update.effective_user.id in banned_users:
+        await update.message.reply_text("🚫 Вы заблокированы в боте.")
+        return
     context.user_data["fight_mode"] = "pve"
     user_id = update.effective_user.id
     team_data = db.get_team(user_id)
@@ -554,6 +558,10 @@ async def start_fight(update: Update, context: ContextTypes.DEFAULT_TYPE):
 
 async def start_duel(update: Update, context: ContextTypes.DEFAULT_TYPE):
     """Join PvP queue without tactic selection."""
+    from helpers.admin_utils import banned_users
+    if update.effective_user.id in banned_users:
+        await update.message.reply_text("🚫 Вы заблокированы в боте.")
+        return
     context.user_data["fight_mode"] = "pvp"
     user = update.effective_user
     user_id = user.id

--- a/helpers/admin_utils.py
+++ b/helpers/admin_utils.py
@@ -1,0 +1,21 @@
+import time
+from typing import Dict, List, Set, Tuple
+
+banned_users: Set[int] = set()
+
+# user_id -> set of used admin commands
+admin_usage_log: Dict[int, Set[str]] = {}
+# user_id -> total count of admin command calls
+admin_usage_count: Dict[int, int] = {}
+# chronological list of (timestamp, user_id, command)
+admin_action_history: List[Tuple[int, int, str]] = []
+
+# user_id -> last activity timestamp
+online_users: Dict[int, float] = {}
+
+
+def record_admin_usage(user_id: int, command: str) -> None:
+    """Record usage of an admin command."""
+    admin_usage_log.setdefault(user_id, set()).add(command)
+    admin_usage_count[user_id] = admin_usage_count.get(user_id, 0) + 1
+    admin_action_history.append((int(time.time()), user_id, command))


### PR DESCRIPTION
## Summary
- add new helper `admin_utils` to track admin activity, bans and online status
- restrict `/whoisadmin` to admins and extend admin menu
- implement admin-only commands: `/ban`, `/unban`, `/logadmin`, `/admintop`, `/stats`, `/broadcast`, `/whoonline`
- track user activity for `/whoonline`
- block banned users from opening packs or fighting

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68605b5bef608321896395c77c4df44b