### PR TITLE
Fix command handling after tracking update

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -2750,8 +2750,13 @@ def main():
     application.job_queue.run_repeating(cleanup_expired, interval=3600)
 
     # track user activity
-    application.add_handler(MessageHandler(filters.ALL, track_user_activity), group=0)
-    application.add_handler(CallbackQueryHandler(track_user_activity, pattern=".*"), group=0)
+    application.add_handler(
+        MessageHandler(filters.ALL, track_user_activity, block=False), group=0
+    )
+    application.add_handler(
+        CallbackQueryHandler(track_user_activity, pattern=".*", block=False),
+        group=0,
+    )
 
     application.add_handler(CommandHandler("start", start))
     application.add_handler(CommandHandler("menu", menu))


### PR DESCRIPTION
## Summary
- ensure `track_user_activity` does not block later handlers

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68605e46bd5c83219770897ab6347847