### PR TITLE
Normalize short stats input in admin edit

### DIFF
--- a/helpers/normalize_stats.py
+++ b/helpers/normalize_stats.py
@@ -1,0 +1,10 @@
+import re
+
+
+def normalize_stats_input(raw: str, pos: str) -> str:
+    """Приводит сырую строку из /editcard к каноническому формату."""
+    raw = raw.strip()
+    if pos == "G":
+        m = re.fullmatch(r"(\d+)\s+([\d.]+)", raw)
+        return f"Поб {m[1]} КН {m[2]}" if m else raw
+    return f"Очки {raw}" if raw.isdigit() else raw

--- a/helpers/tests_normalize_stats.py
+++ b/helpers/tests_normalize_stats.py
@@ -1,0 +1,9 @@
+from helpers.normalize_stats import normalize_stats_input
+
+
+def test_field_player():
+    assert normalize_stats_input("88", "F") == "Очки 88"
+
+
+def test_goalkeeper():
+    assert normalize_stats_input("33 2.22", "G") == "Поб 33 КН 2.22"


### PR DESCRIPTION
## Summary
- add helper to normalize short stats input
- update /editcard admin text handler to use it
- clear SCORE_CACHE after editing
- confirm card stats updated to user
- add unit tests for stats normalization

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686169cd81a08321914498ff6c5089e6