### PR TITLE
Fix cache invalidation after editing card stats

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -605,6 +605,7 @@ def update_card_points(card_id: int) -> None:
     conn.commit()
     conn.close()
     refresh_card_cache(card_id)
+    invalidate_score_cache_for_card(card_id)
 
 def format_card_caption(
     card: dict,


### PR DESCRIPTION
## Summary
- invalidate score caches whenever card points are recalculated

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686170db7b5c8321b20ac35816398921