### PR TITLE
Fix admin edit state reset

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -2434,7 +2434,6 @@ async def giveallcards(update: Update, context: ContextTypes.DEFAULT_TYPE):
         f"✅ Выдано {len(missing)} новых карточек."
     )
 
-    admin_edit_state = {}  # user_id: {step, card_id}
 EDIT_CARDS_PER_PAGE = 20
 
 @admin_only


### PR DESCRIPTION
## Summary
- remove a stray assignment to `admin_edit_state` inside `giveallcards`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686174b3499c8321a80dcece5de9e424