### PR TITLE
Clean duplicate cache logic

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -51,6 +51,12 @@ from collections import Counter
 from functools import wraps
 import handlers
 import db_pg as db
+from cache import (
+    load_card_cache,
+    get_card_from_cache,
+    refresh_card_cache,
+    invalidate_score_cache_for_card,
+)
 from helpers.leveling import xp_to_next
 from helpers import shorten_number, format_ranking_row, format_my_rank
 from helpers.styles import get_player_style
@@ -289,78 +295,12 @@ async def menu_callback(update: Update, context: ContextTypes.DEFAULT_TYPE):
 
 
 # --- Кэш для карточек ---
-CARD_FIELDS = [
-    "id", "name", "img", "pos", "country", "born", "height",
-    "weight", "rarity", "stats", "team_en", "team_ru"
-]
-CARD_CACHE = {}
 RANK_CACHE: dict[int, tuple[int, int, float]] = {}
 SCORE_CACHE: dict[int, tuple[float, float]] = {}
 TOP_CACHE: tuple[list[tuple[int, str | None, float, int]], float] = ([], 0)
 RANK_TTL = 600  # seconds
 SCORE_TTL = 600  # seconds
 TOP_TTL = 600  # seconds
-
-def load_card_cache(force=False):
-    """Загружаем все карточки в память для сокращения обращений к БД."""
-    global CARD_CACHE
-    if CARD_CACHE and not force:
-        return
-    conn = get_db()
-    c = conn.cursor()
-    c.execute(
-        "SELECT id, name, img, pos, country, born, height, weight, rarity, stats, team_en, team_ru FROM cards"
-    )
-    rows = c.fetchall()
-    conn.close()
-    CARD_CACHE = {
-        row[0]: dict(zip(CARD_FIELDS, row))
-        for row in rows
-    }
-
-def get_card_from_cache(card_id):
-    """Возвращает информацию о карте из кэша, при необходимости подгружает её."""
-    if card_id not in CARD_CACHE:
-        conn = get_db()
-        c = conn.cursor()
-        c.execute(
-            "SELECT id, name, img, pos, country, born, height, weight, rarity, stats, team_en, team_ru FROM cards WHERE id=?",
-            (card_id,),
-        )
-        row = c.fetchone()
-        conn.close()
-        if row:
-            CARD_CACHE[card_id] = dict(zip(CARD_FIELDS, row))
-        else:
-            return None
-    return CARD_CACHE.get(card_id)
-
-def refresh_card_cache(card_id):
-    """Обновляем кэш для конкретной карты или очищаем её."""
-    conn = get_db()
-    c = conn.cursor()
-    c.execute(
-        "SELECT id, name, img, pos, country, born, height, weight, rarity, stats, team_en, team_ru FROM cards WHERE id=?",
-        (card_id,),
-    )
-    row = c.fetchone()
-    conn.close()
-    if row:
-        CARD_CACHE[card_id] = dict(zip(CARD_FIELDS, row))
-    else:
-        CARD_CACHE.pop(card_id, None)
-
-def invalidate_score_cache_for_card(card_id: int) -> None:
-    """Reset cached scores and ranks for users owning the given card."""
-    conn = get_db()
-    cur = conn.cursor()
-    cur.execute("SELECT DISTINCT user_id FROM inventory WHERE card_id=?", (card_id,))
-    user_ids = [row[0] for row in cur.fetchall()]
-    conn.close()
-    for uid in user_ids:
-        SCORE_CACHE.pop(uid, None)
-        RANK_CACHE.pop(uid, None)
-    globals()['TOP_CACHE'] = ([], 0)
 
 POS_RU = {
     "C": "Центр",

--- a/handlers.py
+++ b/handlers.py
@@ -1126,7 +1126,7 @@ async def rename_player_text(update: Update, context: ContextTypes.DEFAULT_TYPE)
     new_name = update.message.text.strip()
     db.update_player_name(pid, new_name)
     context.user_data.pop("rename_player", None)
-    from bot import refresh_card_cache
+    from cache import refresh_card_cache
     refresh_card_cache(pid)
     await update.message.reply_text(f"✅ Игрок теперь известен как {new_name}!")
 


### PR DESCRIPTION
## Summary
- centralize card cache utilities in `cache.py`
- remove duplicate cache code from `bot.py`
- update handlers to import cache utilities

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68618c4acaa48321935f977967458e01